### PR TITLE
Move Aqua to Pass for LUD-09 successAction

### DIFF
--- a/lnurl/lud-09-successAction.md
+++ b/lnurl/lud-09-successAction.md
@@ -9,6 +9,7 @@ Spec: [LUD-09](https://github.com/lnurl/luds/blob/luds/09.md)
 | Wallet | Should Support | Tested | Notes |
 |--------|:--------------:|:------:|-------|
 | [Alby Go](https://getalby.com/products/alby-go) | YES | Pass | Description + "Open Link" button |
+| [Aqua](https://www.aquawallet.io/) | YES | Pass | successAction URL & description display after transaction and persist in transaction history |
 | [Blink](https://www.blink.sv/) | YES | Pass | |
 | [Blitz](https://blitz-wallet.com/) | YES | Pass | Opens URL in in-app WebView, tested by Blitz team |
 | [Breez](https://breez.technology/) | YES | Pass | Tested with Misty Breez |
@@ -36,7 +37,6 @@ Spec: [LUD-09](https://github.com/lnurl/luds/blob/luds/09.md)
 | Wallet | Should Support | Notes |
 |--------|:--------------:|-------|
 | [Blixt](https://blixtwallet.github.io/) | YES | Description + URL link + Copy/Open buttons in code |
-| [Aqua](https://www.aquawallet.io/) | NO | Has data model but no UI rendering of successAction |
 | [Electrum](https://electrum.org/) | NO | No successAction handling in code |
 | [Muun](https://muun.com/) | NO | No LNURL-pay code found |
 | [ShockWallet](https://shock.network) | NO | Passes data through but no UI rendering |
@@ -51,13 +51,13 @@ Spec: [LUD-09](https://github.com/lnurl/luds/blob/luds/09.md)
 
 ## Summary
 
-- **Pass (7):** Alby Go, Blink, Blitz, Breez, Phoenix, Wallet of Satoshi, Zeus
+- **Pass (8):** Alby Go, Aqua, Blink, Blitz, Breez, Phoenix, Wallet of Satoshi, Zeus
 - **Fail (11):** Bitkit, Bitnob, Blue Wallet, Coinos, Evento, Fedi, Flash, Lexe, Minibits, Strike, Tether Wallet
 - **N/A (4):** Blockstream Green, Cake Wallet, Primal, River
 - **Should support, untested (1):** Blixt
-- **Should NOT support (6):** Aqua, Cake Wallet, Electrum, Lexe, Muun, ShockWallet
+- **Should NOT support (5):** Cake Wallet, Electrum, Lexe, Muun, ShockWallet
 - **Unknown (8):** Remaining closed-source or no-code-found wallets (includes Machankura)
 
 ## Last updated
 
-2026-04-03
+2026-05-22

--- a/lnurl/lud-09-successAction.md
+++ b/lnurl/lud-09-successAction.md
@@ -9,7 +9,7 @@ Spec: [LUD-09](https://github.com/lnurl/luds/blob/luds/09.md)
 | Wallet | Should Support | Tested | Notes |
 |--------|:--------------:|:------:|-------|
 | [Alby Go](https://getalby.com/products/alby-go) | YES | Pass | Description + "Open Link" button |
-| [Aqua](https://www.aquawallet.io/) | YES | Pass | successAction URL & description display after transaction and persist in transaction history |
+| [Aqua](https://aqua.net/) | YES | Pass | successAction URL & description display after transaction and persist in transaction history |
 | [Blink](https://www.blink.sv/) | YES | Pass | |
 | [Blitz](https://blitz-wallet.com/) | YES | Pass | Opens URL in in-app WebView, tested by Blitz team |
 | [Breez](https://breez.technology/) | YES | Pass | Tested with Misty Breez |

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -15,7 +15,7 @@ If you as an app developer know to look for these domain-specific URI's, you cou
 |----------|----------------|------------------------------|
 | [Alby Go](https://getalby.com/products/alby-go) | [alby:](https://github.com/getAlby/go/blob/5a0f24c0bedceedc0514e4a81af50ba78859f4fb/lib/link.ts#L8) | [alby](https://github.com/getAlby/go/blob/5a0f24c0bedceedc0514e4a81af50ba78859f4fb/lib/link.ts#L8) |
 | [Amber App](https://amber.app/amberwallet) |  |  |
-| [Aqua](https://www.aquawallet.io/) |  |  |
+| [Aqua](https://aqua.net/) |  |  |
 | [Bipa](https://bipa.app/) |  |  |
 | [Bitkit](https://bitkit.to/) | [bitkit:lightning:](https://github.com/synonymdev/bitkit-android/blob/38018018248c8100e6ad204cc62d5b844ad67723/app/src/main/AndroidManifest.xml#L94) | [bitkit](https://github.com/synonymdev/bitkit-ios/blob/11ac9870b989be4f9380a2c8ff92d235fb76ed2a/Bitkit/Info.plist#L13) |
 | [Bitnob](https://bitnob.com/) |  |  |


### PR DESCRIPTION
## Summary
- Moves Aqua from the **Untested** section to **Tested → Pass** for LUD-09 `successAction`.
- Aqua now displays the successAction URL & description after a transaction and persists them in transaction history.
- Updates summary counts (Pass 7→8, Should NOT support 6→5) and "Last updated" date.

## Status
**DO NOT MERGE YET** — pending Aqua's upcoming app release that ships this behavior. Hold this PR open until that version is publicly available.

## Test plan
- [ ] Re-verify end-to-end after the new version is installed
- [ ] Merge once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)