### PR TITLE
Add Bey Wallet to URI schemes and LUD-09 trackers

### DIFF
--- a/lnurl/lud-09-successAction.md
+++ b/lnurl/lud-09-successAction.md
@@ -37,6 +37,7 @@ Spec: [LUD-09](https://github.com/lnurl/luds/blob/luds/09.md)
 | Wallet | Should Support | Notes |
 |--------|:--------------:|-------|
 | [Blixt](https://blixtwallet.github.io/) | YES | Description + URL link + Copy/Open buttons in code |
+| [Bey Wallet](https://github.com/Bey-Wallet/BeyWallet) | NO | Cashu wallet with narrow LN-melt support. [lnurlService.ts](https://github.com/Bey-Wallet/BeyWallet/blob/main/src/services/lnurlService.ts) reads only `data.pr` from the LNURL callback; zero occurrences of `successAction` in the repo. Bech32 `LNURL1...` strings also unsupported |
 | [Electrum](https://electrum.org/) | NO | No successAction handling in code |
 | [Muun](https://muun.com/) | NO | No LNURL-pay code found |
 | [ShockWallet](https://shock.network) | NO | Passes data through but no UI rendering |
@@ -55,9 +56,9 @@ Spec: [LUD-09](https://github.com/lnurl/luds/blob/luds/09.md)
 - **Fail (11):** Bitkit, Bitnob, Blue Wallet, Coinos, Evento, Fedi, Flash, Lexe, Minibits, Strike, Tether Wallet
 - **N/A (4):** Blockstream Green, Cake Wallet, Primal, River
 - **Should support, untested (1):** Blixt
-- **Should NOT support (5):** Cake Wallet, Electrum, Lexe, Muun, ShockWallet
+- **Should NOT support (6):** Bey Wallet, Cake Wallet, Electrum, Lexe, Muun, ShockWallet
 - **Unknown (8):** Remaining closed-source or no-code-found wallets (includes Machankura)
 
 ## Last updated
 
-2026-05-22
+2026-07-17

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -16,6 +16,7 @@ If you as an app developer know to look for these domain-specific URI's, you cou
 | [Alby Go](https://getalby.com/products/alby-go) | [alby:](https://github.com/getAlby/go/blob/5a0f24c0bedceedc0514e4a81af50ba78859f4fb/lib/link.ts#L8) | [alby](https://github.com/getAlby/go/blob/5a0f24c0bedceedc0514e4a81af50ba78859f4fb/lib/link.ts#L8) |
 | [Amber App](https://amber.app/amberwallet) |  |  |
 | [Aqua](https://aqua.net/) |  |  |
+| [Bey Wallet](https://github.com/Bey-Wallet/BeyWallet) | [bey-wallet](https://github.com/Bey-Wallet/BeyWallet/blob/main/app.json#L8) | [bey-wallet](https://github.com/Bey-Wallet/BeyWallet/blob/main/app.json#L8) |
 | [Bipa](https://bipa.app/) |  |  |
 | [Bitkit](https://bitkit.to/) | [bitkit:lightning:](https://github.com/synonymdev/bitkit-android/blob/38018018248c8100e6ad204cc62d5b844ad67723/app/src/main/AndroidManifest.xml#L94) | [bitkit](https://github.com/synonymdev/bitkit-ios/blob/11ac9870b989be4f9380a2c8ff92d235fb76ed2a/Bitkit/Info.plist#L13) |
 | [Bitnob](https://bitnob.com/) |  |  |


### PR DESCRIPTION
## Summary

Adds [Bey Wallet](https://github.com/Bey-Wallet/BeyWallet) (Expo/React Native, Apache 2.0, currently v0.2.0) to both existing trackers.

**Context:** Bey is fundamentally a Cashu (ecash) + Nostr wallet, not a native Lightning wallet — Lightning shows up only at the edges (mint = LN in → ecash; melt = ecash → pay LN invoice). No LN channel management, no bolt12, no NWC.

## Findings

### URI Schemes
- No `android/` or `ios/` directories in repo (generated by `expo prebuild`)
- Only URI scheme declared is `"scheme": "bey-wallet"` in [app.json](https://github.com/Bey-Wallet/BeyWallet/blob/main/app.json#L8) — Expo maps this to both Android intent filter and iOS `CFBundleURLSchemes`
- No `lightning:`, `bitcoin:`, `lnurl:`, `cashu:`, or `nostr:` handlers registered
- Only custom native plugin (`plugins/withHce.js`) is NFC-only, adds no intent filters
- Not a candidate for the MoneyBadger iOS default-app-picker technique

### LUD-09 successAction
- LNURL-pay support exists in [src/services/lnurlService.ts](https://github.com/Bey-Wallet/BeyWallet/blob/main/src/services/lnurlService.ts) (ported from Sovran's coco/utils.ts)
- Handles Lightning addresses (`user@domain.com`) and explicit `lnurlp://` URLs
- Bech32 `LNURL1...` strings explicitly unsupported (tokenUtils throws "LNURL deposits are not yet supported")
- `requestInvoiceFromLnurl()` reads only `data.pr` from callback response — entire successAction field is discarded at the service boundary
- **Zero** occurrences of `successAction` across entire repo (verified via GitHub code search)
- MeltScreen ResultStage shows a static "Successfully paid Lightning invoice" — no dynamic URL rendering path exists
- Classification: Should Support = **NO**; Untested (but testable via bitcoin.co.ke phone-address worker — likely Fail if tested)

## Test plan

- [ ] Verify Bey Wallet row renders correctly in both markdown tables on GitHub
- [ ] (Optional follow-up) Live-test a bitcoin.co.ke phone-address LNURL-pay in Bey to promote from Untested to Fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)